### PR TITLE
fix the decode function of SRVQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/__pycache__/
+__pycache__/
 *.pyc
 processed/
 speech_data/

--- a/AudioCodec/MimiCodec/models/MimiCodec.py
+++ b/AudioCodec/MimiCodec/models/MimiCodec.py
@@ -105,7 +105,7 @@ class MimiCodec(nn.Module):
         import time
         st_time = time.time()
         z_q = self.quantizer.decode(codes)
-        z_q = self.upsample(z_q)
+        z_q = self.upsample(z_q.transpose(1,2))
         z_q = self.decoder_transformer(z_q)[0]
         rec = self.decoder(z_q)
         return rec

--- a/AudioCodec/MimiCodec/quantization/vq_dc.py
+++ b/AudioCodec/MimiCodec/quantization/vq_dc.py
@@ -156,9 +156,9 @@ class SplitResidualVectorQuantizer(nn.Module):
     def decode(self, codes: torch.Tensor) -> torch.Tensor:
         """Decode the given codes to the quantized representation."""
         # codes is [B, K, T], with T frames, K nb of codebooks.
-        quantized = self.rvq_first.get_codes_from_indices(codes[:, : self.n_q_semantic])
+        quantized=self.rvq_first.get_output_from_indices(codes[:, : ,:self.n_q_semantic])
         if codes.shape[1] > self.n_q_semantic:
-            quantized += self.rvq_rest.get_codes_from_indices(codes[:, self.n_q_semantic :])
+            quantized+=self.rvq_rest.get_output_from_indices(codes[:,: ,self.n_q_semantic :])
         return quantized
 
     @property


### PR DESCRIPTION
Now you can rebuild the audio according to mimi's demo.

def mimi(x):
    with torch.no_grad():
        z=model.encode(x.unsqueeze(0))
        z=model.decode(z)
        torchaudio.save("res.wav",src=z.squeeze(0),sample_rate=24000)
